### PR TITLE
[codex] Add Zettelkasten note rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,136 @@
+# AGENTS.md
+
+This repository is a personal second-brain and Zettelkasten-style note system. When creating or editing notes, optimize for durable understanding, clear links, and correct note type selection.
+
+`RULES.md` is the source of truth for note classification. If anything here is ambiguous, follow `RULES.md` conservatively.
+
+## Mission
+
+- Default to evergreen, permanent notes for stable ideas that can stand on their own.
+- Do not force raw captures, highlights, transcripts, or unfinished thinking into permanent notes.
+- Keep the vault useful as a second brain: capture, organize, distill, and connect.
+
+## Where New Notes Go
+
+- Use `content/` for all new notes unless the user explicitly asks for a legacy location.
+- Treat `pages/`, `journals/`, and root-level note files as legacy content. Do not create new notes there by default.
+- Permanent concept notes belong in `content/domains/...` or `content/people/...`.
+- Literature/source notes belong in `content/media/books/`, `content/media/books/highlights/`, `content/media/articles/`, `content/media/podcasts/`, or `content/media/videos/`.
+- Research notes belong in `content/research/...`.
+- Fleeting or daily capture belongs in `content/journal/`.
+
+## Required Decision Before Writing
+
+Every new note must be classified first:
+
+1. `permanent`
+2. `literature`
+3. `research`
+4. `journal`
+
+If the note is not clearly a permanent note, do not create it as permanent.
+
+Use this default decision logic:
+
+- Choose `permanent` when the note explains one durable idea in your own words.
+- Choose `literature` when the note is tied to a source and mainly captures what that source says.
+- Choose `research` when the note contains exploration, comparisons, hypotheses, questions, or unresolved synthesis.
+- Choose `journal` when the note is a fleeting capture, daily log, inbox item, or temporary observation.
+
+## Permanent Note Standard
+
+When creating a permanent note:
+
+- Write in your own words.
+- Keep it atomic: one core idea per note.
+- Use an evergreen title based on the idea, not the source.
+- Explain why the idea matters.
+- Add wikilinks to related notes. Aim for at least 2 meaningful links when the context exists.
+- Prefer concept titles like `Message Authentication Code` or `Identity-based habits`, not titles like `Notes from chapter 3`.
+- Do not copy large quotes into permanent notes.
+
+Permanent notes must not be:
+
+- book highlights
+- article excerpts
+- raw transcripts
+- meeting dumps
+- brainstorming scratchpads
+- unresolved research collections
+- reading notes that only paraphrase one source without synthesis
+
+## Literature Note Standard
+
+When creating a literature note:
+
+- Keep it attached to the source.
+- Preserve quotations, highlights, timestamps, page references, or source-specific context there.
+- Do not present source material as evergreen knowledge unless it has been separately distilled into a permanent note.
+- Link outward to permanent notes that the source supports.
+
+## Research Note Standard
+
+When creating a research note:
+
+- Treat it as a workbench, not as evergreen knowledge.
+- It may contain comparisons, open questions, partial synthesis, experiments, and unresolved claims.
+- Keep it in `content/research/...`.
+- Do not promote it to permanent note status until the material has been distilled into self-contained idea notes.
+
+## Journal / Fleeting Note Standard
+
+When creating a journal note:
+
+- Keep it in `content/journal/`.
+- Use it for capture, not for final storage of knowledge.
+- Promote useful ideas out of the journal into permanent notes later if they become durable and linkable.
+
+## Frontmatter For New Notes
+
+For new notes, keep the existing repository metadata and add `type`:
+
+```yaml
+---
+title: "Note Title"
+date: YYYY-MM-DD
+type: permanent | literature | research | journal
+category: "Domain/Subdomain"
+tags: [tag1, tag2]
+status: draft | incomplete | complete | archived
+source: "Optional source"
+related: ["[[Related Note]]"]
+---
+```
+
+Notes:
+
+- `title`, `date`, and `type` are required for new notes.
+- `category`, `tags`, and `status` should be present whenever they are reasonably known.
+- `source` is expected for literature and research notes tied to external material.
+- `related` is strongly recommended for permanent notes.
+
+## Promotion Rule
+
+Only promote literature or research material into a permanent note when all of the following are true:
+
+- the idea is durable, not merely source-bound
+- it has been rewritten in your own words
+- it can stand alone without the source note
+- it expresses one main idea
+- it connects to the existing note network
+
+When promoting, create a new permanent note rather than silently rebranding the source or research note.
+
+## Editing Existing Notes
+
+- Preserve the existing note's intent and note type.
+- Do not convert a literature or research note into a permanent note unless explicitly asked and the promotion rule is satisfied.
+- Do not move large sets of existing notes between folders unless the user asks for migration work.
+- Prefer adding links, cleanup, and synthesis over rewriting a source note into an evergreen note in place.
+
+## Output Quality Bar
+
+- Favor clarity over completeness.
+- Prefer concise synthesis over long dumps.
+- Avoid duplicate notes when a concept already exists.
+- If a note idea is already covered, update the existing permanent note and add links instead of creating a near-duplicate.

--- a/RULES.md
+++ b/RULES.md
@@ -1,0 +1,194 @@
+# RULES.md
+
+These rules define how notes are classified and written in this repository so the vault behaves like a real second brain instead of a pile of markdown files.
+
+## Core Principles
+
+- Capture quickly, but distill before treating something as knowledge.
+- Permanent notes hold durable understanding.
+- Literature notes hold source-bound material.
+- Research notes hold active inquiry and unfinished synthesis.
+- Journal notes hold fleeting capture.
+- One note should express one main idea.
+- Notes should connect through wikilinks, not rely only on folder structure.
+- Write notes so future-you can understand them without reopening the original source.
+
+## Second Brain Rules
+
+- Capture: put raw material in journal, literature, or research notes first.
+- Organize: place notes by note type and domain, not by temporary convenience.
+- Distill: rewrite ideas in your own words before making them permanent.
+- Express: prefer notes that are reusable in writing, thinking, and connecting to other ideas.
+
+## Note Types
+
+### 1. Permanent Notes
+
+Purpose:
+- Store evergreen ideas, concepts, claims, principles, definitions, or biographies that remain useful over time.
+
+Use a permanent note only when the note:
+- contains one durable idea
+- is written mostly in your own words
+- can stand alone without the original source
+- has a title based on the idea itself
+- links to related notes
+
+Permanent notes belong in:
+- `content/domains/...`
+- `content/people/...`
+
+Permanent note titles should look like:
+- `Entropy measures uncertainty`
+- `Message Authentication Code`
+- `Identity-based habits`
+
+Permanent note titles should not look like:
+- `Notes on Atomic Habits`
+- `Research about entropy`
+- `Chapter 4 summary`
+- `Podcast notes`
+
+### 2. Literature Notes
+
+Purpose:
+- Store notes tied to a specific source such as a book, article, podcast, talk, or video.
+
+Use a literature note when the note:
+- depends on a single source
+- contains highlights, quotations, timestamps, or page references
+- summarizes what the source says
+- is still primarily source-bound rather than idea-bound
+
+Literature notes belong in:
+- `content/media/books/`
+- `content/media/books/highlights/`
+- `content/media/articles/`
+- `content/media/podcasts/`
+- `content/media/videos/`
+
+Literature notes may link to permanent notes, but they are not permanent notes themselves.
+
+### 3. Research Notes
+
+Purpose:
+- Store exploration, comparisons, hypotheses, drafts, question lists, open problems, and topic workbenches.
+
+Use a research note when the note:
+- is synthesizing across multiple sources but is still unfinished
+- contains uncertainty, exploration, or open questions
+- tracks an ongoing investigation
+- would be misleading if treated as settled knowledge
+
+Research notes belong in:
+- `content/research/...`
+
+Research notes are not permanent notes.
+
+### 4. Journal / Fleeting Notes
+
+Purpose:
+- Capture daily thoughts, quick ideas, TODOs, observations, or temporary notes.
+
+Journal notes belong in:
+- `content/journal/`
+
+Journal notes are inbox material. Valuable ideas can later be turned into permanent notes, but journal entries are not permanent notes.
+
+## Hard Boundary: What Must Never Be Called A Permanent Note
+
+Do not classify any of the following as a permanent note:
+
+- direct book highlights
+- page-by-page chapter summaries
+- copied quotations without synthesis
+- article excerpts
+- transcript fragments
+- brainstorming scratchpads
+- TODO lists
+- meeting notes
+- active research logs
+- open question collections
+- speculative drafts that are not yet settled
+
+If there is doubt, downgrade the note to `literature` or `research`.
+
+## Promotion Rules
+
+A literature note or research note can inspire a permanent note, but it should not simply be renamed or moved and called permanent.
+
+Promotion is allowed only if:
+
+1. one clear idea has been extracted
+2. the idea has been rewritten in your own words
+3. the note can be understood without the source material
+4. the note title names the idea, not the source
+5. the note links to related concepts in the vault
+
+Recommended promotion flow:
+
+1. Capture in literature, research, or journal note.
+2. Distill the strongest single idea.
+3. Create a new permanent note in the proper domain.
+4. Link the permanent note back to the originating source or research note.
+
+## Structure Rules For Permanent Notes
+
+Permanent notes should usually include:
+
+- a precise title
+- a short statement of the core idea
+- explanation in your own words
+- links to related notes
+- optional examples, implications, or contrasts
+
+A good permanent note is:
+
+- atomic
+- evergreen
+- linkable
+- reusable
+- comprehensible without rereading the source
+
+## Metadata Rules For New Notes
+
+For new notes, use frontmatter with at least:
+
+```yaml
+---
+title: "Note Title"
+date: YYYY-MM-DD
+type: permanent | literature | research | journal
+tags: [tag1, tag2]
+status: draft | incomplete | complete | archived
+---
+```
+
+Additional fields:
+
+- `category` for domain placement
+- `source` for literature and research notes
+- `related` for explicit note connections
+
+## Folder Rules
+
+- New evergreen knowledge goes into `content/domains/...` or `content/people/...`.
+- New source-bound notes go into `content/media/...`.
+- New exploratory work goes into `content/research/...`.
+- New fleeting capture goes into `content/journal/`.
+- Do not create new notes in legacy paths such as `pages/`, `journals/`, or the repository root unless explicitly requested.
+
+## Duplicate Prevention
+
+Before creating a new permanent note:
+
+- check whether the concept already exists
+- if it exists, improve the existing note instead of creating a near-duplicate
+- if the new note offers a distinct idea, make the distinction explicit in the title and links
+
+## Default Rule
+
+The system should be permanent-note oriented, but not permanent-note careless.
+
+Default to a permanent note only when the material is already distilled and evergreen.
+Otherwise capture it as literature, research, or journal material first, then promote it later if it earns that status.


### PR DESCRIPTION
## What changed
- added `AGENTS.md` to define how agents should create and edit notes in this vault
- added `RULES.md` to define second-brain and Zettelkasten classification rules for permanent, literature, research, and journal notes

## Why
The vault needed explicit guardrails so new notes default to evergreen permanent-note standards only when the material is actually distilled. This prevents literature notes, research workbenches, and fleeting captures from being mislabeled as permanent knowledge.

## Impact
- future note creation is routed into the correct folders under `content/`
- permanent notes are now explicitly required to be atomic, evergreen, source-independent, and linked
- literature and research notes now have a clear promotion path instead of being treated as permanent by default

## Validation
- reviewed the existing repository structure and aligned the rules with the current `content/domains`, `content/media`, `content/research`, and `content/journal` layout
- verified the change set contains only `AGENTS.md` and `RULES.md`
